### PR TITLE
fix object fit to prevent stretching on tablet

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -391,6 +391,7 @@ header {
     @apply block;
     @apply w-full;
     @apply -z-10;
+    @apply object-cover;
 }
 
 .question-image-container {


### PR DESCRIPTION
## Fixes:

- object fit on tablet size

<img width="791" alt="CleanShot 2023-01-11 at 21 53 49@2x" src="https://user-images.githubusercontent.com/57319535/211915606-b6931526-87a4-47f9-88cd-a635f8a2d14d.png">

